### PR TITLE
adding the lines Imports and BugReports to package's index.html

### DIFF
--- a/R/roxy.html.R
+++ b/R/roxy.html.R
@@ -73,8 +73,16 @@ rx.html.switch <- function(desc, field){
   if(field %in% dimnames(desc)[[2]]){
     switch(EXPR=field,
       Depends=rx.tr("Depends:", rx.clean(desc[,"Depends"])),
+      Imports=rx.tr("Imports:", rx.clean(desc[,"Imports"])),
       Suggests=rx.tr("Suggests:", rx.clean(desc[,"Suggests"])),
       Enhances=rx.tr("Enhances:", rx.clean(desc[,"Enhances"])),
+      BugReports=rx.tr("BugReports:", 
+        if(substr(desc[,"BugReports"], 1, 4) != 'http'){
+          rx.clean(desc[,"BugReports"], nomail=FALSE, textmail=TRUE)
+        } else {
+          XMLNode("a", gsub("&", "&amp;", desc[,"BugReports"]),
+          attrs=list(href=gsub("&", "&amp;", desc[,"BugReports"])))
+        }),
       URL=rx.tr("URL:", XMLNode("a",
         gsub("&", "&amp;", desc[,"URL"]),
         attrs=list(href=gsub("&", "&amp;", desc[,"URL"]))))
@@ -275,12 +283,14 @@ roxy.html <- function(pckg, index=FALSE, css="web.css", R.version=NULL,
       XMLNode("table",
         rx.tr("Version:", pckg[,"Version"]),
         rx.html.switch(desc=pckg, field="Depends"),
+        rx.html.switch(desc=pckg, field="Imports"),
         rx.html.switch(desc=pckg, field="Suggests"),
         rx.html.switch(desc=pckg, field="Enhances"),
 #        rx.tr("Published:", pckg[,"Date"]),
         rx.tr("Published:", as.character(as.Date(getDescField(pckg, field=c("Date","Packaged","Date/Publication"))))),
         rx.tr("Author:", pckg.author),
         rx.tr("Maintainer:", pckg.maintainer),
+        rx.html.switch(desc=pckg, field="BugReports"),
         rx.tr("License:", pckg[,"License"]),
         rx.html.switch(desc=pckg, field="URL"),
           if(file_test("-f", cite)){


### PR DESCRIPTION
This pull request adds two lines (Imports, BugReports) to [my_repo]/pckg/[my_package]/index.html which describes the package in a CRAN like fashion.

If Imports, BugReports are part of the package description they will be added to the HTML. The content of Imports is handled identical to Depends/Suggests. BugReports is handled like URL if its content starts with 'http' otherwise the content is cleaned caring for possibly available email.  

I missed those two lines dearly. The user needs to know which other packages are required because of imports. I accept bug reports for one of my packages via email for now but plan to use a proper issue system soon.
