### PR TITLE
Using vignette title as link text

### DIFF
--- a/R/roxy.html.R
+++ b/R/roxy.html.R
@@ -202,7 +202,7 @@ debRepoInfo <- function(URL, dist, comp, repo, repo.name, repo.root,
 # for global repository index outside pckg dir, set index=TRUE and redirect="pckg/"
 #' @import XiMpLe
 roxy.html <- function(pckg, index=FALSE, css="web.css", R.version=NULL,
-  url.src=NULL, url.win=NULL, url.mac=NULL, url.doc=NULL, url.vgn=NULL, url.deb.repo=NULL, main.path.mac=NULL, title=NULL,
+  url.src=NULL, url.win=NULL, url.mac=NULL, url.doc=NULL, url.vgn=NULL, title.vgn=NULL, url.deb.repo=NULL, main.path.mac=NULL, title=NULL,
   cite="", news="", changelog="", redirect="", rss.file=NULL, flattrUser=NULL, URL=NULL) {
 
   rss.header <- rss.feed <- NULL
@@ -349,13 +349,18 @@ roxy.html <- function(pckg, index=FALSE, css="web.css", R.version=NULL,
             url.doc,
             attrs=list(href=url.doc)))},
         if(!is.null(url.vgn)){
-          rx.tr("Vignettes:", XMLNode("",
-            .children=as.list(sapply(url.vgn, function(this.vgn){
-              XMLNode("", .children=list(
-                XMLNode("a", this.vgn, attrs=list(href=this.vgn)),
-                XMLNode("br"))
-              )
-            }))))},
+          if(is.null(title.vgn)){ title.vgn <- url.vgn }
+          rx.tr("Vignettes:", 
+                XMLNode("",
+                        .children=
+                          mapply(function(this.url, this.title){
+                            XMLNode("", .children=list(
+                              XMLNode("a", this.title, attrs=list(href=this.url)),
+                              XMLNode("br")))},
+                            url.vgn, title.vgn, SIMPLIFY=FALSE)
+                )
+          )
+        },
         # add NEWS or ChangeLog
         if(file_test("-f", news)){
           rx.tr("News/ChangeLog:", XMLNode("", .children=list(

--- a/R/roxy.html.R
+++ b/R/roxy.html.R
@@ -350,16 +350,12 @@ roxy.html <- function(pckg, index=FALSE, css="web.css", R.version=NULL,
             attrs=list(href=url.doc)))},
         if(!is.null(url.vgn)){
           if(is.null(title.vgn)){ title.vgn <- url.vgn }
-          rx.tr("Vignettes:", 
-                XMLNode("",
-                        .children=
-                          mapply(function(this.url, this.title){
-                            XMLNode("", .children=list(
-                              XMLNode("a", this.title, attrs=list(href=this.url)),
-                              XMLNode("br")))},
-                            url.vgn, title.vgn, SIMPLIFY=FALSE)
-                )
-          )
+          rx.tr("Vignettes:", XMLNode("", .children=mapply(function(this.url, this.title){
+            XMLNode("", .children=list(
+            XMLNode("a", this.title, attrs=list(href=this.url)),
+            XMLNode("br")))},
+            url.vgn, title.vgn, SIMPLIFY=FALSE)
+          ))
         },
         # add NEWS or ChangeLog
         if(file_test("-f", news)){

--- a/R/roxy.package.R
+++ b/R/roxy.package.R
@@ -844,7 +844,7 @@ roxy.package <- function(
       } else {}
     } else {}
     # check for binaries to link
-    url.src <- url.win <- url.mac <- url.deb <- url.doc <- url.vgn <- deb.repo <- NULL
+    url.src <- url.win <- url.mac <- url.deb <- url.doc <- url.vgn <- title.vgn <- deb.repo <- NULL
     if(file_test("-f", repo.src.gz)){
       url.src <- pckg.name.src
     } else {}
@@ -886,14 +886,14 @@ roxy.package <- function(
     } else {}
     # check for docs to link
     pdf.docs <- file.path(repo.pckg.info, pckg.pdf.doc)
-    # build vignettes seem to be pdf or html
-    vig.names <- basename(tools::file_path_sans_ext(tools::pkgVignettes(dir=pck.source.dir)$docs))
-    vignettes.in.repo <- list.files(repo.pckg.info, paste0("^(", paste(vig.names, collapse='|'), ")\\.(html|pdf)"))
+    # gather information (title, file name) about built vignettes
+    vig.info <- tools::getVignetteInfo(package=pck.package)
     if(file_test("-f", pdf.docs)){
       url.doc <- pckg.pdf.doc
     } else {}
-    if(length(vignettes.in.repo) > 0){
-      url.vgn <- vignettes.in.repo
+    if(nrow(vig.info) > 0){
+      url.vgn <- vig.info[, 7]
+      title.vgn <- vig.info[, 5]
     } else {}
     # check for NEWS.Rd or NEWS file
     if(file_test("-f", pckg.NEWS.Rd)){
@@ -913,7 +913,7 @@ roxy.package <- function(
       RSS.file.name <- NULL
     } else {}
     package.html <- roxy.html(pckg.dscrptn, index=FALSE, css="web.css", R.version=R.Version.win,
-      url.src=url.src, url.win=url.win, url.mac=url.mac, url.doc=url.doc, url.vgn=url.vgn,
+      url.src=url.src, url.win=url.win, url.mac=url.mac, url.doc=url.doc, url.vgn=url.vgn, title.vgn=title.vgn,
       url.deb.repo=url.deb.repo, main.path.mac=OSX.repo[["main"]],
       title=html.title, cite=pckg.cite.file.html, news=url.NEWS,
       changelog=pckg.changelog, rss.file=RSS.file.name,

--- a/R/roxy.package.R
+++ b/R/roxy.package.R
@@ -892,8 +892,14 @@ roxy.package <- function(
       url.doc <- pckg.pdf.doc
     } else {}
     if(nrow(vig.info) > 0){
-      url.vgn <- vig.info[, 7]
-      title.vgn <- vig.info[, 5]
+      if(all( c('Title', 'PDF') %in% colnames(vig.info))){
+        url.vgn <- vig.info[, "PDF"]
+        title.vgn <- vig.info[, "Title"]
+      } else{
+        stop(simpleError(paste("doc: the output format of tools::getVignetteInfo()", 
+                               "is not compatible with this version of roxyPackage.",
+                               "Please consider filing a bug report!")))
+      }
     } else {}
     # check for NEWS.Rd or NEWS file
     if(file_test("-f", pckg.NEWS.Rd)){


### PR DESCRIPTION
Following your good advise to use tools::getVignetteInfo(), it was quite easy to use vignette title as link text. 

Although, I liked the regex for finding the vignettes, which i had to retire now. But is much cleaner now and the HTML looks nicer / more CRAN-like now.
