### PR TITLE
introduce a space between the material items

### DIFF
--- a/R/roxy.html.R
+++ b/R/roxy.html.R
@@ -423,12 +423,15 @@ roxy.html <- function(pckg, index=FALSE, css="web.css", R.version=NULL,
       pckg.materials <- append(pckg.materials, XMLNode("a", "README", attrs=list(href="README.html", class="urls")))
     } else {}
     if(file_test("-f", news)){
+      pckg.materials <- append(pckg.materials, " ")
       pckg.materials <- append(pckg.materials, XMLNode("a", "NEWS", attrs=list(href=gsub("(.*)(NEWS)(.*)", "\\2\\3", news, perl=TRUE), class="urls")))
     } else {}
     if(file_test("-f", changelog)){
+      pckg.materials <- append(pckg.materials, " ")
       pckg.materials <- append(pckg.materials, XMLNode("a", "ChangeLog", attrs=list(href="ChangeLog", class="urls")))
     } else {}
     if(!is.null(rss.feed)){
+      pckg.materials <- append(pckg.materials, " ")
       pckg.materials <- append(pckg.materials, rss.feed)
     } else {}
 


### PR DESCRIPTION
The items in the topic 'Materials:' on the package's HTML-page are written next to each other without a break between the underlined/styled items 

The most simple/naive idea to break the underline was to add a space in the maetrials-list between the a-nodes